### PR TITLE
Return just the id value from register_subject_version

### DIFF
--- a/confluent_schema_registry_client/__init__.py
+++ b/confluent_schema_registry_client/__init__.py
@@ -98,7 +98,7 @@ class SchemaRegistryClient(object):
         data = json.dumps({'schema': json.dumps(schema)})
         res = requests.post(self._url('/subjects/{}/versions', subject), data=data, headers=HEADERS)
         raise_if_failed(res)
-        return res.json()
+        return res.json()['id']
 
     def schema_registration_for_subject(self, subject, schema):
         """

--- a/tests/schema_registry_client_test.py
+++ b/tests/schema_registry_client_test.py
@@ -129,7 +129,7 @@ class TestSchemaRegistryClient(TestCase):
         with Mocker() as m:
             m.post(
                 url('/subjects/test/versions'),
-                json=34)
+                json={'id':34})
             self.assertEquals(
                 34,
                 self.client.register_subject_version('test', SCHEMA))


### PR DESCRIPTION
Owing to a documentation error in the Confluent schema registry this method was returning a dict rather than the schema id. This fixes that.

@paetling 
